### PR TITLE
Fix `proposed_content` pre-population for literature edit button

### DIFF
--- a/docs/javascripts/edit-button.js
+++ b/docs/javascripts/edit-button.js
@@ -1,0 +1,23 @@
+document.addEventListener("click", async function (event) {
+    const link = event.target.closest("a[rel='edit'][data-raw-url]");
+    if (!link) return;
+
+    event.preventDefault();
+
+    const rawUrl = link.dataset.rawUrl;
+    let href = link.href;
+
+    try {
+        const response = await fetch(rawUrl);
+        if (response.ok) {
+            const text = await response.text();
+            // Strip YAML frontmatter block (--- ... ---)
+            const body = text.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, "").trimStart();
+            href += "&proposed_content=" + encodeURIComponent(body);
+        }
+    } catch (_) {
+        // Fall back to navigating without proposed_content
+    }
+
+    window.location.href = href;
+});

--- a/overrides/partials/actions.html
+++ b/overrides/partials/actions.html
@@ -3,7 +3,7 @@
     {% set edit_prefix = config.repo_url ~ "/edit/main/" %}
     {% set filepath = page.edit_url | replace(edit_prefix, "") %}
     {% if "literature" in page.edit_url %}
-      <a href="{{ config.repo_url }}/issues/new?template=edit-literature.yml&labels=edit-literature&title=Edit:%20{{ filepath }}&proposed_content={{ page.markdown | urlencode }}" title="{{ lang.t('action.edit') }}" class="md-content__button md-icon" rel="edit">
+      <a href="{{ config.repo_url }}/issues/new?template=edit-literature.yml&labels=edit-literature&title=Edit:%20{{ filepath }}" data-raw-url="{{ config.repo_url | replace('https://github.com/', 'https://raw.githubusercontent.com/') }}/main/{{ filepath }}" title="{{ lang.t('action.edit') }}" class="md-content__button md-icon" rel="edit">
         {% set icon = config.theme.icon.edit or "material/file-edit-outline" %}
         {% include ".icons/" ~ icon ~ ".svg" %}
       </a>

--- a/zensical.toml
+++ b/zensical.toml
@@ -76,6 +76,7 @@ extra_css = ["stylesheets/reference.css"]
 extra_javascript = [
     "javascripts/mathjax.js",
     "https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js",
+    "javascripts/edit-button.js",
 ]
 
 # Enable tags. See: https://zensical.org/docs/setup/tags/?h=tag


### PR DESCRIPTION
`page.markdown` is not available in Zensical's Jinja2 templates (its build pipeline exposes no markdown key on the page object), so the previous `&proposed_content=` parameter always rendered empty.

Replace it with a JavaScript approach: the edit button now carries a `data-raw-url` attribute (baked in at build time) pointing to the file on `raw.githubusercontent.com`. A click handler fetches that URL, strips the YAML frontmatter, and appends the encoded body as `proposed_content` before navigating to the issue form.

Also add the `edit-literature` and `edit-tutorial` labels to the repo directly, as GitHub silently drops labels specified in issue templates that don't already exist, which was causing the `edit-page-to-pr` workflow to skip on every triggered issue.