### PR TITLE
Formatting fix for adding multiple tags

### DIFF
--- a/.github/workflows/suggest-literature-to-pr.yml
+++ b/.github/workflows/suggest-literature-to-pr.yml
@@ -34,14 +34,23 @@ jobs:
                 # Extract the directory the file needs to go in and make the folder
                 DIR_PATH=$(dirname "$FULL_PATH")
                 mkdir -p "$DIR_PATH"
-                
+
+                # Convert comma-separated tags to YAML list format
+                if [ -n "$TAGS" ]; then
+                    TAGS_LIST=$(echo "$TAGS" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' | sed 's/^/  - /')
+                    TAGS_YAML="tags:
+                ${TAGS_LIST}"
+                else
+                    TAGS_YAML="tags:"
+                fi
+
                 cat <<EOF > "$FULL_PATH"
                 ---
-                tags: $TAGS
+                ${TAGS_YAML}
                 doi: $DOI
                 comments: true
                 ---
-                
+
                 $CONTENT
                 EOF
             


### PR DESCRIPTION
When suggesting new literature using the [`suggest-literature.yml`](https://github.com/Fusion-CDT/community-reading-list/blob/f15691c2e535bcb3a8568e9ed2a72bdcfb600e54/.github/ISSUE_TEMPLATE/suggest-literature.yml) template, users are asked to enter multiple tags as a comma-separated list. This needs to be reformatted as a YAML list in order to display on the web page. Prior to this change, we were just using the raw string.

This affected the following pages that were made using the [`suggest-literature-to-pr.yml`](https://github.com/Fusion-CDT/community-reading-list/blob/15d03df45c33bccd4a21b67edd5832d12ad8eff7/.github/workflows/suggest-literature-to-pr.yml) action: #12, #25 and #27. I'll fix these separately.