### PR TITLE
Bugfix/continuous publication model

### DIFF
--- a/scripts/doi_reference.py
+++ b/scripts/doi_reference.py
@@ -112,12 +112,13 @@ def _format_crossref(data, doi):
         for a in data["author"]
     )
     journal = _first_or_str(data["container-title"])
-    vol = data["volume"]
-    issue = data["issue"]
+    vol = data.get("volume", "")
+    issue = data.get("issue", "")
     pages = data.get("page", data.get("article-number", "")).replace("-", "\u2013")
     year = str(data["issued"]["date-parts"][0][0])
 
-    journal_line = f"<em>{journal}</em>, <b>{vol}</b>({issue}), {pages} ({year})"
+    vol_issue = f"<b>{vol}</b>({issue})" if issue else f"<b>{vol}</b>"
+    journal_line = f"<em>{journal}</em>, {vol_issue}, {pages} ({year})"
     return _header_lines(title, authors, journal_line, doi)
 
 


### PR DESCRIPTION
Some journals (e.g. Nuclear Materials and Energy) use a continuous publication model and omit the `issue` (and sometimes `volume`) field from their Crossref records. Switch from direct key access to `.get()` for both fields, and conditionally omit the issue from the formatted journal line when absent.

Exposed by Fusion-CDT/community-reading-list#25.