### PR TITLE
Allow blank issues and remove redundant link from Issue menu

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Edit an existing entry
-    url: https://fusion-cdt.github.io/community-reading-list/
-    about: Use the edit button on any literature or tutorial page to suggest a correction or improvement via a GitHub issue.


### PR DESCRIPTION
- Allow users to submit blank issues (I think only I've been able to do this so far -- sorry!)
- Removed 'Edit an existing entry' option from Issue menu, which linked users to the reading list. This was added before we had issue templates for editing literature and tutorial notes but is now redundant. The recommended approach is explained in [`CONTRIBUTING.md`](https://github.com/Fusion-CDT/community-reading-list/blob/212e6a8efae1aa3f9bc371dd05d08ad65e4b5be8/CONTRIBUTING.md)