### PR TITLE
Increased website width

### DIFF
--- a/docs/stylesheets/reference.css
+++ b/docs/stylesheets/reference.css
@@ -41,3 +41,12 @@
 .ref-contributors a:hover {
   text-decoration: underline;
 }
+
+/* Increase the main content width */
+.md-container {
+  max-width: 100% !important;
+}
+
+.md-main__inner {
+  max-width: 100% !important;
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 1
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -24,16 +24,7 @@ wheels = [
 ]
 
 [[package]]
-name = "deepmerge"
-version = "2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890, upload-time = "2024-08-30T05:31:50.308Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475, upload-time = "2024-08-30T05:31:48.659Z" },
-]
-
-[[package]]
-name = "fusion-cdt-community-reading-list"
+name = "community-reading-list"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
@@ -42,6 +33,15 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "zensical", specifier = ">=0.0.21" }]
+
+[[package]]
+name = "deepmerge"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890, upload-time = "2024-08-30T05:31:50.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475, upload-time = "2024-08-30T05:31:48.659Z" },
+]
 
 [[package]]
 name = "markdown"


### PR DESCRIPTION
# Increased width of website

Previous website looked a bit thin and especially for technical tutorials which contain a large amount of text, having the website take up the whole of the screen will increase readability in my opinion:
Before:
<img width="1908" height="1248" alt="Screenshot 2026-04-08 at 09-47-14 Get started - Fusion CDT Community Reading List" src="https://github.com/user-attachments/assets/4dab9f55-7b55-481a-abf5-4a526bec9790" />
After:
<img width="1908" height="1099" alt="Screenshot 2026-04-08 at 09-47-21 Get started - Fusion CDT Community Reading List" src="https://github.com/user-attachments/assets/7affc4cd-e05a-4d97-9d70-5d86777f24ec" />

Let me know what you think