### PR TITLE
Fix `force-push` on issue edit

### DIFF
--- a/.github/workflows/suggest-literature-to-pr.yml
+++ b/.github/workflows/suggest-literature-to-pr.yml
@@ -34,6 +34,7 @@ jobs:
 
             - name: Generate markdown file
               if: steps.check-branch.outputs.exists == 'false'
+              id: generate-markdown-file
               shell: bash
               env:
                 DOI: ${{ steps.parser.outputs.parsed_doi }}
@@ -79,7 +80,8 @@ jobs:
                   echo ""
                   echo "$CONTENT"
                 } > "$FULL_PATH"
-            
+                echo "$FULL_PATH" >> $GITHUB_OUTPUT
+
             - name: Create PR
               if: steps.check-branch.outputs.exists == 'false'
               uses: peter-evans/create-pull-request@v6
@@ -88,7 +90,9 @@ jobs:
                 commit-message: "${{ github.event.issue.title }}"
                 title: "${{ github.event.issue.title }}"
                 body: |
-                    Auto-generated PR for adding the suggested literature.
+                    Auto-generated PR for adding the suggested literature. 
+                    
+                    To edit the content of this suggested literature [click here](https://github.com/Fusion-CDT/community-reading-list/edit/add-suggested-literature-${{ github.event.issue.number }}/${{ steps.generate-markdown-file.outputs.FULL_PATH }})
                     
                     Suggested by @${{ github.event.issue.user.login }}
 

--- a/.github/workflows/suggest-literature-to-pr.yml
+++ b/.github/workflows/suggest-literature-to-pr.yml
@@ -14,8 +14,18 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
-            
+
+            - name: Check if PR branch already exists
+              id: check-branch
+              run: |
+                if git ls-remote --heads origin "add-suggested-literature-${{ github.event.issue.number }}" | grep -q .; then
+                  echo "exists=true" >> $GITHUB_OUTPUT
+                else
+                  echo "exists=false" >> $GITHUB_OUTPUT
+                fi
+
             - name: Parse issue
+              if: steps.check-branch.outputs.exists == 'false'
               id: parser
               uses: issue-ops/parser@v5.0.0
               with:
@@ -23,6 +33,7 @@ jobs:
                 issue-form-template: suggest-literature.yml
 
             - name: Generate markdown file
+              if: steps.check-branch.outputs.exists == 'false'
               shell: bash
               env:
                 DOI: ${{ steps.parser.outputs.parsed_doi }}
@@ -70,6 +81,7 @@ jobs:
                 } > "$FULL_PATH"
             
             - name: Create PR
+              if: steps.check-branch.outputs.exists == 'false'
               uses: peter-evans/create-pull-request@v6
               with:
                 base: main

--- a/.github/workflows/suggest-tutorial-to-pr.yml
+++ b/.github/workflows/suggest-tutorial-to-pr.yml
@@ -15,7 +15,17 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
 
+            - name: Check if PR branch already exists
+              id: check-branch
+              run: |
+                if git ls-remote --heads origin "add-suggested-tutorial-${{ github.event.issue.number }}" | grep -q .; then
+                  echo "exists=true" >> $GITHUB_OUTPUT
+                else
+                  echo "exists=false" >> $GITHUB_OUTPUT
+                fi
+
             - name: Parse issue
+              if: steps.check-branch.outputs.exists == 'false'
               id: parser
               uses: issue-ops/parser@v5.0.0
               with:
@@ -23,6 +33,7 @@ jobs:
                 issue-form-template: suggest-tutorial.yml
 
             - name: Generate markdown file
+              if: steps.check-branch.outputs.exists == 'false'
               shell: bash
               env:
                 FILEPATH: ${{ steps.parser.outputs.parsed_filepath }}
@@ -68,6 +79,7 @@ jobs:
                 } > "$FULL_PATH"
 
             - name: Create PR
+              if: steps.check-branch.outputs.exists == 'false'
               uses: peter-evans/create-pull-request@v6
               with:
                 base: main

--- a/.github/workflows/suggest-tutorial-to-pr.yml
+++ b/.github/workflows/suggest-tutorial-to-pr.yml
@@ -34,6 +34,7 @@ jobs:
 
             - name: Generate markdown file
               if: steps.check-branch.outputs.exists == 'false'
+              id: generate-markdown-file
               shell: bash
               env:
                 FILEPATH: ${{ steps.parser.outputs.parsed_filepath }}
@@ -77,6 +78,7 @@ jobs:
                   echo ""
                   echo "$CONTENT"
                 } > "$FULL_PATH"
+                echo "$FULL_PATH" >> $GITHUB_OUTPUT
 
             - name: Create PR
               if: steps.check-branch.outputs.exists == 'false'
@@ -87,6 +89,9 @@ jobs:
                 title: "${{ github.event.issue.title }}"
                 body: |
                     Auto-generated PR for adding the suggested tutorial.
+
+                    To edit the content of this suggested literature [click here](https://github.com/Fusion-CDT/community-reading-list/edit/add-suggested-literature-${{ github.event.issue.number }}/${{ steps.generate-markdown-file.outputs.FULL_PATH }})
+                    
 
                     Suggested by @${{ github.event.issue.user.login }}
 

--- a/.github/workflows/suggest-tutorial-to-pr.yml
+++ b/.github/workflows/suggest-tutorial-to-pr.yml
@@ -90,7 +90,7 @@ jobs:
                 body: |
                     Auto-generated PR for adding the suggested tutorial.
 
-                    To edit the content of this suggested literature [click here](https://github.com/Fusion-CDT/community-reading-list/edit/add-suggested-literature-${{ github.event.issue.number }}/${{ steps.generate-markdown-file.outputs.FULL_PATH }})
+                    To edit the content of this suggested literature [click here](https://github.com/Fusion-CDT/community-reading-list/edit/add-suggested-tutorial-${{ github.event.issue.number }}/${{ steps.generate-markdown-file.outputs.FULL_PATH }})
                     
 
                     Suggested by @${{ github.event.issue.user.login }}


### PR DESCRIPTION
When an issue was edited, the suggest-literature and suggest-tutorial workflows would regenerate the file and force-push to the existing PR branch, overwriting any manual commits. Added a branch-existence check so the parse/generate/PR steps are skipped if the branch already exists.

Closes #74