### PR TITLE
Add ability to specify url names as well as URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest-literature-lecture-notes.yml
+++ b/.github/ISSUE_TEMPLATE/suggest-literature-lecture-notes.yml
@@ -36,6 +36,15 @@ body:
       required: false
 
   - type: input
+    id: url_name
+    attributes:
+      label: URL name(s)
+      description: Replace the raw URLs with specific names, if unspecified then the raw links are rendered. Separate multiple URL names with commas.
+      placeholder: "e.g. Plasma Physics 1, Plasma Physics 2"
+    validations:
+      required: false
+
+  - type: input
     id: filepath
     attributes:
       label: Location and filename

--- a/.github/ISSUE_TEMPLATE/suggest-literature-textbook.yml
+++ b/.github/ISSUE_TEMPLATE/suggest-literature-textbook.yml
@@ -38,9 +38,18 @@ body:
   - type: input
     id: url
     attributes:
-      label: URL
-      description: A link to the textbook (e.g. publisher page or open-access version), if available.
-      placeholder: "e.g. https://example.com/book"
+      label: URL(s)
+      description: A link to the textbook (e.g. publisher page or open-access version), if available. Additional links to other material. Separate multiple URLs with commas.
+      placeholder: "e.g. https://example.com/book, https://example.com/book/lecture"
+    validations:
+      required: false
+
+  - type: input
+    id: url_name
+    attributes:
+      label: URL name(s)
+      description: Replace the raw URLs with specific names, if unspecified then the raw links are rendered. Separate multiple URL names with commas.
+      placeholder: "e.g. Book, Accompanying lecture slides"
     validations:
       required: false
 

--- a/.github/workflows/_suggest-literature-to-pr.yml
+++ b/.github/workflows/_suggest-literature-to-pr.yml
@@ -50,6 +50,7 @@ jobs:
                 AUTHORS: ${{ steps.parser.outputs.parsed_authors }}
                 ISBN: ${{ steps.parser.outputs.parsed_isbn }}
                 URL: ${{ steps.parser.outputs.parsed_url }}
+                URL_NAME: ${{ steps.parser.outputs.parsed_url_name }}
                 FILEPATH: ${{ steps.parser.outputs.parsed_filepath }}
                 TAGS: ${{ steps.parser.outputs.parsed_tags }}
                 CONTENT: ${{ steps.parser.outputs.parsed_content }}
@@ -85,6 +86,16 @@ jobs:
                     else
                       echo "url:"
                       echo "$URL" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' | sed 's/^/  - "/' | sed 's/$/"/'
+                    fi
+                  fi
+
+                  if [ -n "$URL_NAME" ]; then
+                    URL_NAME_COUNT=$(echo "$URL_NAME" | tr ',' '\n' | grep -cv '^[[:space:]]*$')
+                    if [ "$URL_NAME_COUNT" -eq 1 ]; then
+                      echo "url_name: \"$(echo "$URL_NAME" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')\""
+                    else
+                      echo "url_name:"
+                      echo "$URL_NAME" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' | sed 's/^/  - "/' | sed 's/$/"/'
                     fi
                   fi
 

--- a/scripts/title_reference.py
+++ b/scripts/title_reference.py
@@ -23,6 +23,11 @@ from markdown.preprocessors import Preprocessor
 class TitleReferencePreprocessor(Preprocessor):
     """Inject a formatted reference header for pages with a frontmatter title but no doi."""
 
+    def _as_list(self, value):
+        if not value:
+            return []
+        return value if isinstance(value, list) else [value]
+
     def _meta_from_render_frame(self):
         """Read frontmatter meta dict from Zensical's `render()` frame."""
         for frame_info in inspect.stack():
@@ -58,18 +63,17 @@ class TitleReferencePreprocessor(Preprocessor):
 
         url_frontmatter = []
         if url:
-            urls = url if isinstance(url, list) else [url]
-            if url_name:
-                url_names = url_name if isinstance(url_name, list) else [url_name]
-            elif url_name is None:
-                url_names = []
-            for u, u_name in zip_longest(urls, url_names):
-                name = u_name if u_name is not None else u
-                url_frontmatter.append(f"<a href='{u}'>{name}</a>")
+            urls = self._as_list(url)
+            url_names = self._as_list(url_name)
+            url_frontmatter = []
+            for url, url_name in zip_longest(urls, url_names):
+                label = url_name if url_name is not None else url
+                url_frontmatter.append(f"<a href='{url}'>{label}</a>")
 
-        header.append(
-            f"<p class='ref-url'><b>URL(s):</b> {', '.join(url_frontmatter)}</p>"
-        )
+            header.append(
+                f"<p class='ref-url'><b>URL(s):</b> {', '.join(url_frontmatter)}</p>"
+            )
+
         header += ["", "---", ""]
 
         return header + lines

--- a/scripts/title_reference.py
+++ b/scripts/title_reference.py
@@ -14,6 +14,7 @@ Follows the same stack-inspection pattern as `doi_reference.py` and
 """
 
 import inspect
+from itertools import zip_longest
 
 from markdown import Extension
 from markdown.preprocessors import Preprocessor
@@ -45,6 +46,7 @@ class TitleReferencePreprocessor(Preprocessor):
         authors = meta.get("authors")
         isbn = meta.get("isbn")
         url = meta.get("url")
+        url_name = meta.get("url_name")
 
         header = [f"# {title}"]
 
@@ -54,11 +56,20 @@ class TitleReferencePreprocessor(Preprocessor):
         if isbn:
             header.append(f"<p class='ref-isbn'><b>ISBN:</b> {isbn}</p>")
 
+        url_frontmatter = []
         if url:
             urls = url if isinstance(url, list) else [url]
-            for u in urls:
-                header.append(f"<p class='ref-url'><b>URL:</b> <a href='{u}'>{u}</a></p>")
+            if url_name:
+                url_names = url_name if isinstance(url_name, list) else [url_name]
+            elif url_name is None:
+                url_names = []
+            for u, u_name in zip_longest(urls, url_names):
+                name = u_name if u_name is not None else u
+                url_frontmatter.append(f"<a href='{u}'>{name}</a>")
 
+        header.append(
+            f"<p class='ref-url'><b>URL(s):</b> {', '.join(url_frontmatter)}</p>"
+        )
         header += ["", "---", ""]
 
         return header + lines
@@ -74,9 +85,7 @@ class TitleReferenceExtension(Extension):
     """
 
     def extendMarkdown(self, md):
-        md.preprocessors.register(
-            TitleReferencePreprocessor(md), "title_reference", 30
-        )
+        md.preprocessors.register(TitleReferencePreprocessor(md), "title_reference", 30)
 
 
 def makeExtension(**kwargs):


### PR DESCRIPTION
Sometimes URLs can get very long and become very difficult to read so we should allow the user to specify URL names using the new frontmatter `url_name` which takes a single item or a list and replaces the raw URL with the word or sentence. 

If the length of the names does not equal the number of urls then the raw link is rendered instead.

Example:
<img width="680" height="147" alt="image" src="https://github.com/user-attachments/assets/b236cf12-bfc3-4dcc-bc82-d0784c40ed51" />
