### PR TITLE
Cleanup/frontmatter textbook and lecture notes

### DIFF
--- a/docs/literature/Machine Learning/mitchell1997machine-learning.md
+++ b/docs/literature/Machine Learning/mitchell1997machine-learning.md
@@ -7,15 +7,23 @@ tags:
   - Genetic Algorithms
   - Reinforcement Learning
   - Backpropagation
-doi: 
+title: Machine learning (Book)
+authors: Tom Mitchell, McGraw Hill
+isbn: 0070428077
+url: 
+  - https://www.cs.cmu.edu/~tom/mlbook.html
+  - https://www.cs.cmu.edu/%7Etom/10701_sp11/lectures.shtml
+url_name:
+  - Book
+  - Accompanying lecture course
 contributors:
   - name: "Joe Umpleby-Thorp"
     github: "JoeUT"
 comments: true
 ---
 
-General introduction to machine learning.
-Includes sections on: 
+Includes sections on:
+
 - Decision trees
 - Artificial neural networks
 - Bayesian learning
@@ -25,8 +33,5 @@ Includes sections on:
 
 It has a particularly useful description of choosing a learning algorithm and setting out a hypothesis.
 It also includes a good description of the backpropagation algorithm.
-
-**Book website:** [https://www.cs.cmu.edu/~tom/mlbook.html](url)
-**Accompanying lecture course:** [https://www.cs.cmu.edu/%7Etom/10701_sp11/lectures.shtml](url)
 
 The website also includes the full pdf, additional chapters on estimating probabilities, and Naive Bayes and Logistic Regression, as well as accompanying software and data.

--- a/docs/literature/plasma/LPI/SFQED/kropf2026SFQED-Primer.md
+++ b/docs/literature/plasma/LPI/SFQED/kropf2026SFQED-Primer.md
@@ -11,4 +11,4 @@ comments: true
 
 As the title suggests, this is a primer of strong field quantumelectrodynamics (SFQED), relevant for those doing ultra-intense laser-plasma interactions. 
 
-It systematically introduces key paremeters that people use in the field ($\chi$, $\eta$, $\xi$, $). It describes the Furry picture and relevant assumptions (LCFA and LMA). Several important nonlinear QED processes, such as (inverse) nonlinear Compton Scattering, photon-photon interactions (Breit-Wheeler and light-light scattering)  are also discussed. In addition, it provides a nice explanation on when different regimes are relevant. Finally, it summarises key environments where SFQED is relevant.
+It systematically introduces key paremeters that people use in the field ($\chi$, $\eta$, $\xi$). It describes the Furry picture and relevant assumptions (LCFA and LMA). Several important nonlinear QED processes, such as (inverse) nonlinear Compton Scattering, photon-photon interactions (Breit-Wheeler and light-light scattering)  are also discussed. In addition, it provides a nice explanation on when different regimes are relevant. Finally, it summarises key environments where SFQED is relevant.

--- a/docs/literature/plasma/MCF/EPFL_Plasma_Lectures.md
+++ b/docs/literature/plasma/MCF/EPFL_Plasma_Lectures.md
@@ -5,20 +5,21 @@ tags:
 - MHD
 - MCF
 - ICF
-doi: null
+title: EPFL Plasma Physics Online Lecture Course
+authors: A. Fasoli, P. Ricci, A. Howling, C. Theiler, D. Testa, I. Furno, J. P. Hogge
+url: 
+  - https://courseware.epfl.ch/courses/course-v1:EPFL+PlasmaIntroduction+1T_2018/about
+  - https://courseware.epfl.ch/courses/course-v1:EPFL+PlasmaApplication+1T_2018/about
+url_name: 
+  - Plasma Physics Introduction
+  - Plasma Physics Applications
 contributors:
 - name: Felix Watts
   github: FelixWattsYork
 comments: true
 ---
 
-# EPFL Plasma Physics Online Lecture Course
-
-This online lecture course serves as an introduction to plasma physics, starting from the kinetic description of a plasma and working through to the fluid description (MHD). The second part of this course, _Plasma Phyiscs: Applications_, covers astrophysical plasmas, low temperature plasmas, and fusion plasmas relevant to both MCF and ICF contexts.
-
-**Plasma Physics Introduction:** <https://courseware.epfl.ch/courses/course-v1:EPFL+PlasmaIntroduction+1T_2018/about>
-
-**Plasma Physics Applications:** <https://courseware.epfl.ch/courses/course-v1:EPFL+PlasmaApplication+1T_2018/about>
+This online lecture course serves as an introduction to plasma physics, starting from the kinetic description of a plasma and working through to the fluid description (MHD). The second part of this course, _Plasma Physics: Applications_, covers astrophysical plasmas, low temperature plasmas, and fusion plasmas relevant to both MCF and ICF contexts.
 
 This is a complete lecture course including online lectures, problems with example solutions, and lecture notes.
 

--- a/docs/literature/plasma/MCF/SOL/eich2017ELM-divertor-energy-fluence.md
+++ b/docs/literature/plasma/MCF/SOL/eich2017ELM-divertor-energy-fluence.md
@@ -9,7 +9,9 @@ tags:
   - ASDEX-Upgrade
 doi: 10.1016/j.nme.2017.04.014
 comments: true
-contributors: [{name: "John Lloyd Baker", github: "PoloidalLloyd"}]
+contributors: 
+  - name: "John Lloyd Baker"
+    github: "PoloidalLloyd"
 ---
 
 Excellent paper on model development for estimated target heat flux loading due to type 1 ELM's, derived via multi-machine scalings and applied to the ITER Tokamak.

--- a/docs/literature/plasma/MCF/SOL/krasheninnikov-2013-SOL-turbulence.md
+++ b/docs/literature/plasma/MCF/SOL/krasheninnikov-2013-SOL-turbulence.md
@@ -2,7 +2,9 @@
 tags: SOL-turbulence, turbulence
 doi: 10.1017/S0022377807006940
 comments: true
-contributors: [{name: "Roman Ghiam", github: "MagneticRoman"}]
+contributors: 
+  - name: "Roman Ghiam"
+    github: "MagneticRoman"
 ---
 
 This paper highlights recent progress in theoretical developments in understanding Coherent Structures in the edge and SOL.

--- a/docs/literature/plasma/MCF/Waves/parra2019Collisionless-Plasma-Physics.md
+++ b/docs/literature/plasma/MCF/Waves/parra2019Collisionless-Plasma-Physics.md
@@ -6,19 +6,26 @@ tags:
   - Theory
   - Cold Plasma
   - Hot Plasma
-doi: 
+title: Collisionless Plasma Physics (Waves in Plasmas)
+url: 
+  - https://github.com/user-attachments/files/26439914/ClPP.Lecture.Notes.1.pdf
+  - https://github.com/user-attachments/files/26439914/ClPP.Lecture.Notes.2.pdf
+  - https://github.com/user-attachments/files/26439914/ClPP.Lecture.Notes.3.pdf
+url_name: 
+  - ClPP Lecture Notes 1.pdf
+  - ClPP Lecture Notes 2.pdf
+  - ClPP Lecture Notes 3.pdf
+authors: Felix I. Parra
 contributors:
   - name: "Zheyuan Chen"
     github: "ZheyuanChen"
 comments: true
 ---
 
-# Collisionless Plasma Physics (Waves in Plasmas)
-
 This is a set of lecture notes from the first half of Oxford's MMathPhys course _Collisionless Plasma Physics_. It focuses on wave phenomena in plasmas.
 
-[ClPP Lecture Notes 1.pdf](https://github.com/user-attachments/files/26439914/ClPP.Lecture.Notes.1.pdf): Cold Plasma Waves Focuses on cold plasma waves. Felix starts with Maxwell equations, derives the general cold plasma dispersion relation, and then examines several important cases (Alfven waves, ordinary and extraordinary modes, circularly polarised waves, etc).
+**ClPP Lecture Notes 1.pdf**: Cold Plasma Waves Focuses on cold plasma waves. Felix starts with Maxwell equations, derives the general cold plasma dispersion relation, and then examines several important cases (Alfven waves, ordinary and extraordinary modes, circularly polarised waves, etc).
 
-[ClPP Lecture Notes 2.pdf](https://github.com/user-attachments/files/26439913/ClPP.Lecture.Notes.2.pdf): Wave propagation in an inhomogeneous plasma. Focuses on wave propagation in an inhomogeneous plasma, introduces techniques like WKB approximation and ray tracing, and discusses cutoffs and resonances.
+**ClPP Lecture Notes 2.pdf**: Wave propagation in an inhomogeneous plasma. Focuses on wave propagation in an inhomogeneous plasma, introduces techniques like WKB approximation and ray tracing, and discusses cutoffs and resonances.
 
-[ClPP Lecture Notes 3.pdf](https://github.com/user-attachments/files/26439915/ClPP.Lecture.Notes.3.pdf): Hot Plasma Waves. Has a light, utilitarian touch on the kinetic theory formalism that is required to describe hot plasma waves. Touches on electron cyclotron damping and electron Bernstein waves.
+**ClPP Lecture Notes 3.pdf**: Hot Plasma Waves. Has a light, utilitarian touch on the kinetic theory formalism that is required to describe hot plasma waves. Touches on electron cyclotron damping and electron Bernstein waves.

--- a/docs/literature/plasma/MCF/costley_2015_power-size-fusion-pilot-plants-and-reactors.md
+++ b/docs/literature/plasma/MCF/costley_2015_power-size-fusion-pilot-plants-and-reactors.md
@@ -8,7 +8,9 @@ tags:
   - low-power
 doi: 10.1088/0029-5515/55/3/033001
 comments: true
-contributors: [{name: "Rhoen Eate", github: "rhoeneate3"}]
+contributors: 
+  - name: "Rhoen Eate"
+    github: "rhoeneate3"
 ---
 
 Nice intro to triple product significance and general fusion power plant design and configurations. Shows that fusion gain mostly depends on absolute level of fusion power and energy confinement, not so much device size.

--- a/docs/literature/plasma/MCF/diagnostics/laviron_1996_reflectometry_techniques_density_measurements.md
+++ b/docs/literature/plasma/MCF/diagnostics/laviron_1996_reflectometry_techniques_density_measurements.md
@@ -7,7 +7,9 @@ tags:
   - density
 doi: 10.1088/0741-3335/38/7/002
 comments: true
-contributors: [{name: "Rhoen Eate", github: "rhoeneate3"}]
+contributors:
+  - name: "Rhoen Eate"
+    github: "rhoeneate3"
 ---
 
 Excellent intro to reflectometry techniques, theory, and general working operations.

--- a/docs/literature/plasma/MCF/gyrokinetics/abel2013multiscale-gyrokinetics.md
+++ b/docs/literature/plasma/MCF/gyrokinetics/abel2013multiscale-gyrokinetics.md
@@ -4,7 +4,9 @@ tags:
   - gyrokinetics
 doi: 10.1088/0034-4885/76/11/116201
 comments: true
-contributors: [{name: "Bailey Cook", github: "baiway"}]
+contributors: 
+  - name: "Bailey Cook"
+    github: "baiway"
 ---
 
 Thorough tutorial paper.

--- a/docs/literature/plasma/MCF/gyrokinetics/highcock2012zero-turbulence.md
+++ b/docs/literature/plasma/MCF/gyrokinetics/highcock2012zero-turbulence.md
@@ -5,7 +5,9 @@ tags:
   - GS2
 doi: 10.48550/arXiv.1207.4419
 comments: true
-contributors: [{name: "Bailey Cook", github: "baiway"}]
+contributors: 
+  - name: "Bailey Cook"
+    github: "baiway"
 ---
 
 Really useful paper for understanding GS2.

--- a/docs/literature/plasma/MCF/gyrokinetics/howes2006astro-gyrokinetics.md
+++ b/docs/literature/plasma/MCF/gyrokinetics/howes2006astro-gyrokinetics.md
@@ -4,7 +4,9 @@ tags:
   - MCF
 doi: 10.1086/506172
 comments: true
-contributors: [{name: "Bailey Cook", github: "baiway"}]
+contributors:
+  - name: "Bailey Cook"
+    github: "baiway"
 ---
 
 Very nice tutorial paper. Appendix A is particularly useful. Note that the authors are interested in astrophysical applications rather than tokamak physics, so they use derive the gyrokinetic system in periodic-slab geometry with a uniform equilibrium magnetic field and no mean temperature or density gradients.

--- a/docs/literature/plasma/MCF/gyrokinetics/kotschenreuther1995gs2.md
+++ b/docs/literature/plasma/MCF/gyrokinetics/kotschenreuther1995gs2.md
@@ -5,7 +5,9 @@ tags:
   - GS2
 doi: 10.1016/0010-4655(95)00035-E
 comments: true
-contributors: [{name: "Bailey Cook", github: "baiway"}]
+contributors: 
+  - name: "Bailey Cook"
+    github: "baiway"
 ---
 
 OG GS2 paper

--- a/docs/literature/plasma/MCF/parra2019Collisional-Plasma-Physics-2025.md
+++ b/docs/literature/plasma/MCF/parra2019Collisional-Plasma-Physics-2025.md
@@ -7,21 +7,16 @@ tags:
   - Resistive MHD
   - Braginskii
   - Pfirsch Schluter
-doi: 
+title: Collisional Plasma Physics (2025 Oxford MMathPhys Course)
+url: https://www-thphys.physics.ox.ac.uk/people/FelixParra/CollisionalPlasmaPhysics/CollisionalPlasmaPhysics.html
+authors: Sarah Newton (2025), Plamen Ivanov (2026)
 contributors:
   - name: "Zheyuan Chen"
     github: "ZheyuanChen"
 comments: true
 ---
 
-# Collisional Plasma Physics (2025 Oxford MMathPhys Course)
-
 This is a set of lecture notes of Oxford's MMathPhys course Collisional Plasma Physics taught in Trinity Term 2025. 
 It starts with the Fokker-Planck collision operator in kinetic equation (1.1 and 1.2), walks through linearised collision operators and Spitzer-Harm problem (1.3), Braginskii fluid equations (2), resistive MHD and NTMs (3), and lands on Tokamak physics (Grad-Shafranov, transports, etc.) (4).
-
-- The 2025 course was taught by Sarah Newton from the UKAEA.
-- The 2026 course was taught by Plamen Ivanov from the UKAEA.
-
-One can find the public course page here: <https://www-thphys.physics.ox.ac.uk/people/FelixParra/CollisionalPlasmaPhysics/CollisionalPlasmaPhysics.html>
 
 In addition to the lecture notes, there are accompanying problem sheets and recommended readings.

--- a/docs/literature/plasma/MCF/schekochihin2026MHD-Kinetic-Theory.md
+++ b/docs/literature/plasma/MCF/schekochihin2026MHD-Kinetic-Theory.md
@@ -4,17 +4,16 @@ tags:
   - MHD
   - Kinetic Theory
   - Theory
-doi: 
+title: Lectures on Kinetic Theory and Magnetohydrodynamics of Plasmas
+url: https://www-thphys.physics.ox.ac.uk/people/AlexanderSchekochihin/KT/2015/KTLectureNotes.pdf
+url_name: Lecture notes
+authors: AA Schekochihin
 contributors:
   - name: "Zheyuan Chen"
     github: "ZheyuanChen"
 comments: true
 ---
 
-# Lectures on Kinetic Theory and Magnetohydrodynamics of Plasmas
-
 A very good introduction to theoretical plasma physics. Part III is a standalone introduction to MHD, assuming basic knowledge of fluid mechanics. Part I introduces kinetic theory, of which Chapters 1 and 2 provide excellent introduction, roadmaps, and general overviews and are quite useful if you don't want delve deeply into the theory (useful concepts like Debye length, plasma frequency, etc. are introduced here).
 
 Note that the author's primary field is theoretical astrophysical plasma, so these lecture notes are not specifically aimed at fusion plasma (tho there's quite a lot of overlap). Nevertheless, this still serves as a rigorous and systematic introduction to theoretical plasma physics. If you are interested in turbulence theory, kinetic MHD (KMHD), and drift kinetics, this is also a valuable starting point.
-
-Link to the lecture notes: [Lectures on Kinetic Theory and Magnetohydrodynamics of Plasmas by AA Schekochihin](https://www-thphys.physics.ox.ac.uk/people/AlexanderSchekochihin/KT/2015/KTLectureNotes.pdf)

--- a/docs/literature/plasma/MCF/zonal-flows/itoh2006zonal-flows.md
+++ b/docs/literature/plasma/MCF/zonal-flows/itoh2006zonal-flows.md
@@ -4,7 +4,9 @@ tags:
   - MCF
 doi: 10.1063/1.2178779
 comments: true
-contributors: [{name: "Bailey Cook", github: "baiway"}]
+contributors:
+  - name: "Bailey Cook"
+    github: "baiway"
 ---
 
 Excellent review paper.

--- a/docs/tutorials/TGLF.md
+++ b/docs/tutorials/TGLF.md
@@ -17,11 +17,11 @@ TGLF is a Gyrofluid qausilinear model of turbulent fluxes. It exists in a class 
 ## Useful Links
 
 Documentation:
-https://gafusion.github.io/doc/tglf.html
-https://gacode.io/
 
-Github:
-https://github.com/gafusion/gacode/
+- <https://gafusion.github.io/doc/tglf.html>
+- <https://gacode.io/>
+
+Github: <https://github.com/gafusion/gacode/>
 
 
 ## Physics background
@@ -32,28 +32,23 @@ The growth rate is calculated via constructing the linearized gyrofluid equation
 
 There are 3 Saturation rules in use in TGLF, with more in development. They work independently of the linear solver, although their validity does depend on the linear solvers accuracy. The Saturation rules used in TGLF will be carried over to its successor GFTM
 
-The best source on workings of TGLF can be found in its original papers:
-https://pubs.aip.org/aip/pop/article/14/5/055909/929642/A-theory-based-transport-model-with-comprehensive
-with this second paper having the best explanation of the effects of numerical parameters of TGLF results
-https://pubs.aip.org/aip/pop/article/12/10/102508/316815/Gyro-Landau-fluid-equations-for-trapped-and
+The best source on workings of TGLF can be found in its original papers: <https://pubs.aip.org/aip/pop/article/14/5/055909/929642/A-theory-based-transport-model-with-comprehensive>
+with this second paper having the best explanation of the effects of numerical parameters of TGLF results <https://pubs.aip.org/aip/pop/article/12/10/102508/316815/Gyro-Landau-fluid-equations-for-trapped-and>
 
-However it's shortfalls are best high lighted in the paper on its sequel GFS, which explicitly points out its failures in high beta regions;
-https://pubs.aip.org/aip/pop/article/30/10/102501/2914182/A-flexible-gyro-fluid-system-of-equations
+However it's shortfalls are best high lighted in the paper on its sequel GFS, which explicitly points out its failures in high beta regions; <https://pubs.aip.org/aip/pop/article/30/10/102501/2914182/A-flexible-gyro-fluid-system-of-equations>
 
  For its saturation rules, the best introduction to both the theory of saturation rules and their specific implementation is Harry Dudding's thesis, specifically chapter 4. This thesis also contains the methodology for the development of the latest saturation rule for TGLF, sat 3
 
-https://etheses.whiterose.ac.uk/id/eprint/32664/
+<https://etheses.whiterose.ac.uk/id/eprint/32664/>
 
 However, For a more in depth explanation of methodology behind the original saturation rule development, here are the original papers for Sat 1 and Sat 2. The original Sat 0 paper is also useful as an introduction to the mixing length approximation 
 
-Sat 1:
-https://iopscience.iop.org/article/10.1088/0029-5515/53/11/113017
+Sat 1: <https://iopscience.iop.org/article/10.1088/0029-5515/53/11/113017>
 
-Sat 2:
-https://iopscience.iop.org/article/10.1088/1741-4326/ac243a/pdf
+Sat 2: <https://iopscience.iop.org/article/10.1088/1741-4326/ac243a/pdf>
 
-Sat 0:
-https://pubs.aip.org/aip/pop/article/15/5/055908/1015727/The-first-transport-code-simulations-using-the
+Sat 0: <https://pubs.aip.org/aip/pop/article/15/5/055908/1015727/The-first-transport-code-simulations-using-the>
 
 ## Running TGLF
+
 TGLF can be downloaded from the GA code GitHub repository. For a specific machine an environment file will need to be specified before the code can be compiled and run. TGLF inputs and outputs are well documented on the gacode website, however it is recommended to use the python package Pyrokinetics (see associated tutorial), for reading outputs.


### PR DESCRIPTION
Closes #102, here we migrate to the latest frontmatter format for both textbooks and lecture notes. Also included is some general housekeeping to cleanup broken links, old frontmatter for contributors and other misc things.

Requires #104 to work.
