### PR TITLE
Fix incorrect assignment of filepath to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/_suggest-literature-to-pr.yml
+++ b/.github/workflows/_suggest-literature-to-pr.yml
@@ -99,7 +99,7 @@ jobs:
                   echo ""
                   echo "$CONTENT"
                 } > "$FULL_PATH"
-                echo "FULL_PATH=$FULL_PATH" >> $GITHUB_OUTPUT
+                echo "filepath=$FULL_PATH" >> $GITHUB_OUTPUT
 
             - name: Create PR
               if: steps.check-branch.outputs.exists == 'false'
@@ -111,7 +111,7 @@ jobs:
                 body: |
                     Auto-generated PR for adding the suggested ${{ inputs.type_name }}.
 
-                    To edit the content of this suggested ${{ inputs.type_name }} [click here](https://github.com/Fusion-CDT/community-reading-list/edit/${{ inputs.branch_prefix }}-${{ github.event.issue.number }}/${{ steps.generate-markdown-file.outputs.FULL_PATH }})
+                    To edit the content of this suggested ${{ inputs.type_name }} [click here](https://github.com/Fusion-CDT/community-reading-list/edit/${{ inputs.branch_prefix }}-${{ github.event.issue.number }}/${{ steps.generate-markdown-file.outputs.filepath }})
 
                     Suggested by @${{ github.event.issue.user.login }}
 

--- a/.github/workflows/suggest-tutorial-to-pr.yml
+++ b/.github/workflows/suggest-tutorial-to-pr.yml
@@ -78,7 +78,7 @@ jobs:
                   echo ""
                   echo "$CONTENT"
                 } > "$FULL_PATH"
-                echo "$FULL_PATH" >> $GITHUB_OUTPUT
+                echo "filepath=$FULL_PATH" >> $GITHUB_OUTPUT
 
             - name: Create PR
               if: steps.check-branch.outputs.exists == 'false'
@@ -90,7 +90,7 @@ jobs:
                 body: |
                     Auto-generated PR for adding the suggested tutorial.
 
-                    To edit the content of this suggested literature [click here](https://github.com/Fusion-CDT/community-reading-list/edit/add-suggested-tutorial-${{ github.event.issue.number }}/${{ steps.generate-markdown-file.outputs.FULL_PATH }})
+                    To edit the content of this suggested literature [click here](https://github.com/Fusion-CDT/community-reading-list/edit/add-suggested-tutorial-${{ github.event.issue.number }}/${{ steps.generate-markdown-file.outputs.filepath }})
                     
 
                     Suggested by @${{ github.event.issue.user.login }}


### PR DESCRIPTION
Whoops... messed up an assignment in the workflows causing the tutorials to stop building. This should fix it.