### PR TITLE
Add missing `title_reference.py` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
 ]
 
 [tool.hatch.build.targets.wheel]
-include = ["scripts/doi_reference.py", "scripts/contributors.py"]
+include = ["scripts/doi_reference.py", "scripts/contributors.py", "scripts/title_reference.py"]
 
 [tool.hatch.build.targets.wheel.sources]
 "scripts" = ""


### PR DESCRIPTION
Website isn't building currently because we forgot to include the new file in the `pyproject`

Seems to build correctly now!